### PR TITLE
Add missing `require "securerandom"` in ActiveSupport::EncryptedFile

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "securerandom"
 require "tmpdir"
 require "active_support/message_encryptor"
 


### PR DESCRIPTION
### Summary

`SecureRandom` is used in `generate_key` but was never required in this file. This doesn't fix any bugs in Rails but lets me save a line in one of my applications. 💜 